### PR TITLE
use REDIRECTION instead of TPROXY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 tests/integration/*-tester/lib/
 .env
 .vscode/
+*.egg-info

--- a/src/charm.py
+++ b/src/charm.py
@@ -222,7 +222,7 @@ class IstioCoreCharm(ops.CharmBase):
 
     # This is a hacky way to get istio CNI to use REDIRECTION instead of TPROXY
     # TODO: Remove this once we upgrade to istio 1.24 as REDIRECTION will be used by default
-    # Istioctl doesn't yet support adding env vars directly to the CNI component https://github.com/istio/istio/blob/master/manifests/charts/istio-cni/values.yaml
+    # Istioctl doesn't yet support adding env vars directly to the CNI component
     def _patch_istio_cni_daemonset(self):
         """Patch the 'istio-cni-node' DaemonSet to add or update the 'AMBIENT_TPROXY_REDIRECTION' key."""
         daemonset_name = "istio-cni-node"

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,12 +6,15 @@
 """A Juju charm for managing the Istio service mesh control plane."""
 
 import logging
+import time
 from pathlib import Path
 
 import ops
 
 # Ignore pyright errors until https://github.com/gtsystem/lightkube/pull/70 is released
 from lightkube import Client, codecs  # type: ignore
+from lightkube.core.exceptions import ApiError
+from lightkube.models.core_v1 import EnvVar
 from lightkube.resources.admissionregistration_v1 import (
     MutatingWebhookConfiguration,
     ValidatingWebhookConfiguration,
@@ -85,7 +88,8 @@ class IstioCoreCharm(ops.CharmBase):
         self._reconcile_gateway_api_crds()
         self._reconcile_istio_crds()
         self._reconcile_control_plane()
-
+        # TODO: Remove after upgrading to istio 1.24
+        self._patch_istio_cni_daemonset()
         # TODO: check if the deployment was successful before setting charm to active
         self.unit.status = ops.ActiveStatus()
 
@@ -215,6 +219,39 @@ class IstioCoreCharm(ops.CharmBase):
             profile="minimal",
             setting_overrides=setting_overrides,
         )
+
+    # This is a hacky way to get istio CNI to use REDIRECTION instead of TPROXY
+    # TODO: Remove this once we upgrade to istio 1.24 as REDIRECTION will be used by default
+    # Istioctl doesn't yet support adding env vars directly to the CNI component https://github.com/istio/istio/blob/master/manifests/charts/istio-cni/values.yaml
+    def _patch_istio_cni_daemonset(self):
+        """Patch the 'istio-cni-node' DaemonSet to add or update the 'AMBIENT_TPROXY_REDIRECTION' key."""
+        daemonset_name = "istio-cni-node"
+        key = "AMBIENT_TPROXY_REDIRECTION"
+        value = "false"
+        check_interval = 10
+        client = self.lightkube_client
+
+        # Iterating for 100 Seconds until we find the CNI DaemonSet
+        for _ in range(10):
+            try:
+                ds = client.get(DaemonSet, daemonset_name, namespace=self.model.name)
+                # Modify the environment variable for container "istio-cni"
+                for container in ds.spec.template.spec.containers:  # pyright: ignore
+                    if container.name == "install-cni":
+                        updated_env = False
+                        for env_var in container.env:  # pyright: ignore
+                            if env_var.name == key:
+                                env_var.value = value
+                                updated_env = True
+                        if not updated_env:
+                            container.env.append(EnvVar(name=key, value=value))  # pyright: ignore
+
+                client.patch(DaemonSet, daemonset_name, obj=ds, namespace=self.model.name)
+                return
+            except ApiError:
+                LOGGER.warning("DaemonSet not found, retrying...")
+                time.sleep(check_interval)
+        raise RuntimeError(f"Failed to patch DaemonSet '{daemonset_name}'.")
 
 
 if __name__ == "__main__":

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -15,7 +15,8 @@ def istio_core_charm():
     with patch.object(IstioCoreCharm, "_reconcile_control_plane"):
         with patch.object(IstioCoreCharm, "_reconcile_istio_crds"):
             with patch.object(IstioCoreCharm, "_reconcile_gateway_api_crds"):
-                yield IstioCoreCharm
+                with patch.object(IstioCoreCharm, "_patch_istio_cni_daemonset"):
+                    yield IstioCoreCharm
 
 
 @pytest.fixture()

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -15,8 +15,7 @@ def istio_core_charm():
     with patch.object(IstioCoreCharm, "_reconcile_control_plane"):
         with patch.object(IstioCoreCharm, "_reconcile_istio_crds"):
             with patch.object(IstioCoreCharm, "_reconcile_gateway_api_crds"):
-                with patch.object(IstioCoreCharm, "_patch_istio_cni_daemonset"):
-                    yield IstioCoreCharm
+                yield IstioCoreCharm
 
 
 @pytest.fixture()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -33,10 +33,8 @@ class TestCharm:
     @patch.object(IstioCoreCharm, "_reconcile_gateway_api_crds")
     @patch.object(IstioCoreCharm, "_reconcile_istio_crds")
     @patch.object(IstioCoreCharm, "_reconcile_control_plane")
-    @patch.object(IstioCoreCharm, "_patch_istio_cni_daemonset")
     def test_charm_begins_active(
         self,
-        _patch_istio_cni_daemonset,
         _reconcile_control_plane,
         _reconcile_istio_crds,
         _reconcile_gateway_api_crds,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,7 +35,12 @@ class TestCharm:
     @patch.object(IstioCoreCharm, "_reconcile_control_plane")
     @patch.object(IstioCoreCharm, "_patch_istio_cni_daemonset")
     def test_charm_begins_active(
-        self, _reconcile_control_plane, _reconcile_istio_crds, _reconcile_gateway_api_crds, harness
+        self,
+        _patch_istio_cni_daemonset,
+        _reconcile_control_plane,
+        _reconcile_istio_crds,
+        _reconcile_gateway_api_crds,
+        harness,
     ):
         harness.begin_with_initial_hooks()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -33,6 +33,7 @@ class TestCharm:
     @patch.object(IstioCoreCharm, "_reconcile_gateway_api_crds")
     @patch.object(IstioCoreCharm, "_reconcile_istio_crds")
     @patch.object(IstioCoreCharm, "_reconcile_control_plane")
+    @patch.object(IstioCoreCharm, "_patch_istio_cni_daemonset")
     def test_charm_begins_active(
         self, _reconcile_control_plane, _reconcile_istio_crds, _reconcile_gateway_api_crds, harness
     ):


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/istio-beacon-k8s-operator/issues/10

## Solution
A fix for a socket release race condition was added as part of https://github.com/istio/istio/issues/52260 and was backported into istio 1.23.1 in https://github.com/istio/istio/pull/52911, change is disabled in the backport and can only be enabled via setting an env var `AMBIENT_TPROXY_REDIRECTION` to false, This PR patches the ENV in the `DaemonSet` as Istioctl doesn't yet support adding env vars directly to the [CNI component](https://github.com/istio/istio/blob/master/manifests/charts/istio-cni/values.yaml) 

## Testing Instructions
1. juju deploy istio-beacon-k8s
2. juju deploy traefik-k8s
3. juju config istio-beacon-k8s model-on-mesh=true
4. Traefik restarts successfully

