### PR TITLE
feat: add config to enable PILOT_AUTO_ALLOW_WAYPOINT_POLICY

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,6 +16,19 @@ config:
       default: true
       description: >
         Enable Istio's ambient mode.  See https://istio.io/latest/docs/ambient/overview/ for details.
+    auto-allow-waypoint-policy:
+      type: boolean
+      default: true
+      description: >
+        For workloads on an ambient mesh with traffic routed through a waypoint, that traffic passing through the 
+        waypoint to the workload can be controlled by L4 authorization policies like any other traffic.  This generally
+        means that, to allow traffic from a waypoint to a workload, users must create L4 authorization policies between
+        the waypoint and the workload.  
+        If this option is set to true, Istio will create synthetic authorization policies allowing waypoints to 
+        communicate with their workloads automatically.  
+        If this option is set to false, users must create L4 authorization policies between waypoints and the workloads.
+        See [PILOT_AUTO_ALLOW_WAYPOINT_POLICY]https://istio.io/latest/docs/reference/commands/pilot-discovery/#envvars
+        for more detail.
     cni-bin-dir:
       type: string
       default: '/var/snap/microk8s/current/opt/cni/bin'

--- a/src/charm.py
+++ b/src/charm.py
@@ -214,6 +214,9 @@ class IstioCoreCharm(ops.CharmBase):
             setting_overrides["components.ztunnel.enabled"] = "true"
             setting_overrides["values.profile"] = "ambient"
 
+        if self.parsed_config["auto-allow-waypoint-policy"]:
+            setting_overrides["values.pilot.env.PILOT_AUTO_ALLOW_WAYPOINT_POLICY"] = "true"
+
         return Istioctl(
             istioctl_path="./istioctl",
             namespace=self.model.name,

--- a/src/config.py
+++ b/src/config.py
@@ -9,3 +9,4 @@ class CharmConfig(BaseModel):
     ambient: bool
     cni_bin_dir: str = Field(alias="cni-bin-dir")
     cni_conf_dir: str = Field(alias="cni-conf-dir")
+    auto_allow_waypoint_policy: bool = Field(alias="auto-allow-waypoint-policy")


### PR DESCRIPTION
## Issue
For workloads on an ambient mesh with traffic routed through a waypoint, that traffic passing through the waypoint to the workload can be controlled by L4 authorization policies like any other traffic.  This generally means that, to allow traffic from a waypoint to a workload, users must create L4 authorization policies between the waypoint and the workload.  

This PR adds a config option to enable the istio-pilot [PILOT_AUTO_ALLOW_WAYPOINT_POLICY](https://istio.io/latest/docs/reference/commands/pilot-discovery/#envvars) environment variable, which tells istio-pilot to automatically generate these L4 policies between the waypoint and workloads.  

## Testing Instructions
* deploy charm
* the `istiod` pod should have `PILOT_AUTO_ALLOW_WAYPOINT_POLICY:  true` in its environment variable section (see `kubectl describe pod istiod-XXX | \grep --color=auto AUTO`)
