### PR TITLE
Bump to 1.24.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -90,7 +90,7 @@ parts:
     build-packages: [git, rustc, cargo]
   istioctl:
     plugin: dump
-    source: https://github.com/istio/istio/releases/download/1.23.1/istioctl-1.23.1-linux-amd64.tar.gz
+    source: https://github.com/istio/istio/releases/download/1.24.0/istioctl-1.24.0-linux-amd64.tar.gz
     source-type: tar
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -228,7 +228,7 @@ class IstioCoreCharm(ops.CharmBase):
     def _get_istioctl(self) -> Istioctl:
         """Return an initialized Istioctl instance."""
         # Default settings
-        setting_overrides = dict()
+        setting_overrides = {}
 
         # Enable Envoy access logs
         # (see https://istio.io/latest/docs/tasks/observability/logs/access-log/)

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,7 @@ LOGGER = logging.getLogger(__name__)
 
 SOURCE_PATH = Path(__file__).parent
 
-CONTROL_PLANE_COMPONENTS = ["Pilot", "Cni", "Ztunnel"]
+CONTROL_PLANE_COMPONENTS = ["pilot", "cni", "ztunnel"]
 CONTROL_PLANE_LABEL = "control-plane"
 CONTROL_PLANE_RESOURCE_TYPES = {
     ClusterRole,
@@ -58,7 +58,7 @@ CONTROL_PLANE_RESOURCE_TYPES = {
     ServiceAccount,
     ValidatingWebhookConfiguration,
 }
-ISTIO_CRDS_COMPONENTS = ["Base"]
+ISTIO_CRDS_COMPONENTS = ["base"]
 ISTIO_CRDS_LABEL = "istio-crds"
 ISTIO_CRDS_RESOURCE_TYPES = {CustomResourceDefinition}
 GATEWAY_API_CRDS_MANIFEST = [SOURCE_PATH / "manifests" / "gateway-apis-crds.yaml"]
@@ -232,10 +232,7 @@ class IstioCoreCharm(ops.CharmBase):
     def _get_istioctl(self) -> Istioctl:
         """Return an initialized Istioctl instance."""
         # Default settings
-        setting_overrides = {
-            "components.base.enabled": "true",
-            "components.pilot.enabled": "true",
-        }
+        setting_overrides = dict()
 
         # Enable Envoy access logs
         # (see https://istio.io/latest/docs/tasks/observability/logs/access-log/)
@@ -243,7 +240,6 @@ class IstioCoreCharm(ops.CharmBase):
 
         # Configure CNI
         # (see https://istio.io/latest/docs/setup/additional-setup/cni/#additional-configuration)
-        setting_overrides["components.cni.enabled"] = "true"
         setting_overrides["values.cni.cniBinDir"] = self.parsed_config["cni-bin-dir"]
         setting_overrides["values.cni.cniConfDir"] = self.parsed_config["cni-conf-dir"]
 
@@ -256,7 +252,6 @@ class IstioCoreCharm(ops.CharmBase):
         ] = "0.0.0.0/0"
 
         if self.parsed_config["ambient"]:
-            setting_overrides["components.ztunnel.enabled"] = "true"
             setting_overrides["values.profile"] = "ambient"
 
         if self.parsed_config["auto-allow-waypoint-policy"]:
@@ -265,7 +260,7 @@ class IstioCoreCharm(ops.CharmBase):
         return Istioctl(
             istioctl_path="./istioctl",
             namespace=self.model.name,
-            profile="minimal",
+            profile="empty",
             setting_overrides=setting_overrides,
         )
 

--- a/tests/unit/test_istioctl.py
+++ b/tests/unit/test_istioctl.py
@@ -139,7 +139,7 @@ def test_istioctl_manifest_with_setting_overrides_and_components(mocked_check_ou
     for k, v in setting_overrides.items():
         expected_call_args.extend(["--set", f"{k}={v}"])
     for c in components:
-        expected_call_args.extend(["--component", c])
+        expected_call_args.extend(["--set", f"components.{c}.enabled=true"])
 
     mocked_check_output.assert_called_once_with(expected_call_args)
 


### PR DESCRIPTION
## Issue
#27 

## Solution

This bumps istioctl, and thus istio, to 1.24.0.  Changes also include:

*  refactoring how we invoke `istioctl manifest generate` because `istioctl` deprecated the `--component` arg.  Previously, the `--component` let you select a segment of the overall manifests (eg: `--component Base` returned only the CRDs).  However, this was redundant with the `--set components.X.enabled=true` args, which let you opt into components, and was removed.  We've refactored to using the preferred method, where we now only generate the components that are defined by `--set components.X.enabled=true` args
* removing a temporary configuration from the cni: Previously, #17 added temporary configuration to the Istio CNI.  This was to enable a backport of a bugfix.  The configuration is now default in 1.24.0, so we can remove our patch.

## Context
-

## Testing Instructions
covered by integration tests

## Upgrade Notes
tried a few times doing `juju refresh` from 1.23 to 1.24 and it worked every time.