### PR TITLE
feat: add config for `platform`, remove `cni-*-dir`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,6 +29,16 @@ config:
         If this option is set to false, users must create L4 authorization policies between waypoints and the workloads.
         See [PILOT_AUTO_ALLOW_WAYPOINT_POLICY]https://istio.io/latest/docs/reference/commands/pilot-discovery/#envvars
         for more detail.
+    platform:
+      type: string
+      default: 'microk8s'
+      description: >
+        Some Kubernetes platforms require platform-specific configuration for Istio to function correctly.  This is 
+        described in more detail upstream in [Platform Prerequisites](https://istio.io/latest/docs/ambient/install/platform-prerequisites/).
+        This configuration option maps to the `values.global.platform` field in the Istio Helm chart, and can be used to
+        specify the platform-specific configuration for the Kubernetes platform on which the charm is deployed.  If left
+        blank, no value of `values.global.platform` will be set.
+
     cni-bin-dir:
       type: string
       default: '/var/snap/microk8s/current/opt/cni/bin'

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,27 +39,6 @@ config:
         specify the platform-specific configuration for the Kubernetes platform on which the charm is deployed.  If left
         blank, no value of `values.global.platform` will be set.
 
-    cni-bin-dir:
-      type: string
-      default: '/var/snap/microk8s/current/opt/cni/bin'
-      description: >
-        Path to CNI binaries. This path depends on the Kubernetes installation, for example:
-        * microk8s (default): /var/snap/microk8s/current/opt/cni/bin
-        * many other Kubernetes installations: /opt/cni/bin
-        Refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
-        and https://istio.io/latest/docs/ambient/install/platform-prerequisites/
-        for information to find out the correct path for your Kubernetes installation.
-    cni-conf-dir:
-      type: string
-      default: '/var/snap/microk8s/current/args/cni-network'
-      description: >
-        Path to conflist files describing the CNI configuration. This path depends on the Kubernetes installation, for example:
-        * microk8s (default): /var/snap/microk8s/current/args/cni-network
-        * many other Kubernetes installations: /etc/cni/net.d
-        Refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
-        and https://istio.io/latest/docs/ambient/install/platform-prerequisites/
-        for information to find out the correct path for your Kubernetes installation.
-
 assumes:
   - k8s-api
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -287,10 +287,9 @@ class IstioCoreCharm(ops.CharmBase):
         # (see https://istio.io/latest/docs/tasks/observability/logs/access-log/)
         setting_overrides["meshConfig.accessLogFile"] = "/dev/stdout"
 
-        # Configure CNI
-        # (see https://istio.io/latest/docs/setup/additional-setup/cni/#additional-configuration)
-        setting_overrides["values.cni.cniBinDir"] = self.parsed_config["cni-bin-dir"]
-        setting_overrides["values.cni.cniConfDir"] = self.parsed_config["cni-conf-dir"]
+        # Ignore the platform setting if it's not set or is empty
+        if self.parsed_config["platform"]:
+            setting_overrides["values.global.platform"] = self.parsed_config["platform"]
 
         # Configure the sidecar injector to exclude outbound traffic to all IP ranges.  This is a
         # workaround for CNI limitations with init containers

--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,5 @@ class CharmConfig(BaseModel):
     """Manager for the charm configuration."""
 
     ambient: bool
-    cni_bin_dir: str = Field(alias="cni-bin-dir")  # type: ignore
-    cni_conf_dir: str = Field(alias="cni-conf-dir")  # type: ignore
+    platform: str = Field()  # type: ignore
     auto_allow_waypoint_policy: bool = Field(alias="auto-allow-waypoint-policy")  # type: ignore


### PR DESCRIPTION
## Issue

microk8s places cni binaries and configuration in a non-standard location.  Istio needs these locations to implement its cni plugin.  Previously, we accounted for this through exposing the cni-*-dir configurations.  This works, but is likely unfamiliar to the user and error prone.

## Solution

istio 1.24.0 includes preconfigured settings for microk8s and other platforms via the `values.global.platform` helm chart value.  The microk8s configuration applies the cni-*-dir configurations we previously provided manually.  This commit PR to using the platform config because it is more straight forward and easier for users to understand.

## Context
-

## Testing Instructions
integration tests cover this

If you're really keen, you can run the istioctl commands before and after this change, such as:

old:
```
istioctl manifest generate --set profile=empty --set values.global.istioNamespace=istio-system --set meshConfig.accessLogFile=/dev/stdout --set values.cni.cniBinDir=/var/snap/microk8s/current/opt/cni/bin --set values.cni.cniConfDir=/var/snap/microk8s/current/args/cni-network --set values.sidecarInjectorWebhook.injectedAnnotations.traffic\.sidecar\.istio\.io/excludeOutboundIPRanges=0.0.0.0/0 --set values.profile=ambient --set components.cni.enabled=true
```
vs new:
```
istioctl manifest generate --set profile=empty --set values.global.istioNamespace=istio-system --set meshConfig.accessLogFile=/dev/stdout --set values.global.platform=microk8s --set values.sidecarInjectorWebhook.injectedAnnotations.traffic\.sidecar\.istio\.io/excludeOutboundIPRanges=0.0.0.0/0 --set values.profile=ambient --set components.cni.enabled=true
```

I've confirmed that they both output the same manifests so this is entirely just different config for the same outcome

## Upgrade Notes
this amounts to a no-op change to the deployment, it swaps istioctl arguments for something that is equivalent