### PR TITLE
feat: add istio-metadata relation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -67,10 +67,12 @@ containers:
     resource: metrics-proxy-image
 
 provides:
-  metrics-endpoint:
-    interface: prometheus_scrape
   grafana-dashboard:
     interface: grafana_dashboard
+  istio-metadata:
+    interface: istio_metadata
+  metrics-endpoint:
+    interface: prometheus_scrape
 
 requires:
   charm-tracing:

--- a/lib/charms/istio_k8s/v0/istio_metadata.py
+++ b/lib/charms/istio_k8s/v0/istio_metadata.py
@@ -1,0 +1,209 @@
+"""istio_metadata.
+
+This library implements endpoint wrappers for the istio-metadata interface.  The istio-metadata interface is used to
+transfer information about an instance of Istio, such as its root namespace.  Typically, this is useful for charms that
+need details on how to interface with Istio.
+
+## Usage
+
+### Requirer
+
+IstioMetadataRequirer is a wrapper for pulling data from the istio-metadata interface.  To use it in your charm:
+
+* observe the relation-changed and relation-broken events for this relation wherever your charm needs to use this data
+  (this endpoint wrapper DOES NOT automatically observe any events)
+* wherever you need access to the data, call `IstioMetadataRequirer(...).get_data()`
+
+An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+
+        istio_metadata = IstioMetadataRequirer(self.model.relations, "istio-metadata")
+
+        self.framework.observe(self.on["istio-metadata"].relation_changed, self._on_istio_metadata_changed)
+        self.framework.observe(self.on["istio-metadata"].relation_broken, self._on_istio_metadata_changed)
+
+    def _on_istio_metadata_changed(self):
+        data = istio_metadata.get_data()
+        ...
+```
+
+Where you also add relation to your `charmcraft.yaml` or `metadata.yaml` (note that IstioMetadataRequirer is designed
+for relating to a single application and must be used with limit=1 as shown below):
+
+```yaml
+requires:
+  istio-metadata:
+    limit: 1
+    interface: istio_metadata
+```
+
+### Provider
+
+IstioMetadataProvider is a wrapper for publishing data to charms related using the istio-metadata interface.  Note
+that `IstioMetadataProvider` *does not* manage any events, but instead provides a `publish` method for sending data to
+all related applications.  Triggering `publish` appropriately is left to the charm author, although generally you want
+to do this at least during the `relation_joined` and `leader_elected` events.  An example implementation is:
+
+```python
+class FooCharm(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.istio_metadata = IstioMetadataProvider(
+            relation_mapping=self.model.relations,
+            app=self.app,
+            relation_name="istio-metadata",
+        )
+
+        self.framework.observe(self.on.leader_elected, self.do_something_to_publish)
+        self.framework.observe(self._charm.on["istio-metadata"].relation_joined, self.do_something_to_publish)
+        self.framework.observe(self.on.some_event_that_changes_istio_metadata, self.do_something_to_publish)
+
+    def do_something_to_publish(self, e):
+        self.istio_metadata.publish(...)
+```
+
+Where you also add the following to your `charmcraft.yaml` or `metadata.yaml`:
+
+```yaml
+provides:
+  istio-metadata:
+    interface: istio_metadata
+```
+"""
+
+import logging
+from typing import Optional
+
+from ops import Application, RelationMapping
+from pydantic import BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+
+LIBID = "23257732473e4bb39d47e4a4b4e97bc2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+PYDEPS = ["pydantic>=2"]
+
+log = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "istio-metadata"
+
+
+class IstioMetadataAppData(BaseModel):
+    """Data model for the istio-metadata interface."""
+
+    root_namespace: str = Field(
+        description="The root namespace for the Istio installation.",
+        examples=["istio-system"],
+    )
+
+
+class IstioMetadataRequirer:
+    """Endpoint wrapper for the requirer side of the istio-metadata relation."""
+
+    def __init__(
+        self,
+        relation_mapping: RelationMapping,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        """Initialize the IstioMetadataRequirer object.
+
+        This object is for accessing data from relations that use the istio-metadata interface.  It **does not**
+        autonomously handle the events associated with that relation.  It is up to the charm using this object to
+        observe those events as they see fit.  Typically, that charm should observe this relation's relation-changed
+        event.
+
+        This object is for interacting with a relation that has limit=1 set in charmcraft.yaml.  In particular, the
+        get_data method will raise if more than one related application is available.
+
+        Args:
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm
+                              object).
+            relation_name: The name of the wrapped relation.
+        """
+        self._charm_relation_mapping = relation_mapping
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the relation instances for applications related to us on the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    def get_data(self) -> Optional[BaseModel]:
+        """Return data for at most one related application, raising if more than one is available.
+
+        Useful for charms that always expect exactly one related application.  It is recommended that those charms also
+        set limit=1 for that relation in charmcraft.yaml.  Returns None if no data is available (either because no
+        applications are related to us, or because the related application has not sent data).
+        """
+        relations = self.relations
+        if len(relations) == 0:
+            return None
+        if len(relations) > 1:
+            raise ValueError("Cannot get_info when more than one application is related.")
+
+        # Being a little cautious here using getattr and get, since some funny things have happened with relation data
+        # in the past.
+        raw_data_dict = getattr(relations[0], "data", {}).get(relations[0].app)
+        if not raw_data_dict:
+            return None
+
+        return IstioMetadataAppData.model_validate(raw_data_dict)
+
+
+class IstioMetadataProvider:
+    """The provider side of the istio-metadata relation."""
+
+    def __init__(
+        self,
+        relation_mapping: RelationMapping,
+        app: Application,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize the IstioMetadataProvider object.
+
+        This object is for serializing and sending data to a relation that uses the istio-metadata interface - it does
+        not automatically observe any events for that relation.  It is up to the charm using this to call publish when
+        it is appropriate to do so, typically on at least the charm's leader_elected event and this relation's
+        relation_joined event.
+
+        Args:
+            relation_mapping: The RelationMapping of a charm (typically `self.model.relations` from within a charm object).
+            app: This application.
+            relation_name: The name of the relation.
+        """
+        self._charm_relation_mapping = relation_mapping
+        self._app = app
+        self._relation_name = relation_name
+
+    @property
+    def relations(self):
+        """Return the applications related to us under the monitored relation."""
+        return self._charm_relation_mapping.get(self._relation_name, ())
+
+    def publish(self, root_namespace: str):
+        """Post istio-metadata to all related applications.
+
+        This method writes to the relation's app data bag, and thus should never be called by a unit that is not the
+        leader otherwise ops will raise an exception.
+
+        Args:
+            root_namespace: The root namespace of the Istio deployment.
+        """
+        data = IstioMetadataAppData(root_namespace=root_namespace).model_dump(
+            mode="json", by_alias=True, exclude_defaults=True, round_trip=True
+        )
+
+        for relation in self.relations:
+            databag = relation.data[self._app]
+            databag.update(data)

--- a/tests/scenario/test_istio_metadata_implementation.py
+++ b/tests/scenario/test_istio_metadata_implementation.py
@@ -1,0 +1,58 @@
+"""Tests that assert IstioCharm is wired up correctly to be a istio-metadata provider."""
+
+import pytest
+from ops.testing import Model, Relation, State
+
+RELATION_NAME = "istio-metadata"
+INTERFACE_NAME = "istio_metadata"
+
+# Note: if this is changed, the IstioMetadataAppData concrete classes below need to change their constructors to match
+SAMPLE_APP_DATA = {"root_namespace": "root-namespace"}
+
+
+@pytest.mark.parametrize("model_name", ["istio", "istio-system"])
+def test_provider_sender_sends_data_on_relation_joined(istio_core_context, model_name):
+    """Tests that a charm using IstioMetadataProvider sends the correct data on a relation joined event."""
+    # Arrange
+    relation = Relation(RELATION_NAME, INTERFACE_NAME)
+    relations = [relation]
+
+    state = State(
+        relations=relations,
+        leader=True,
+        model=Model(model_name),
+    )
+
+    expected = {"root_namespace": model_name}
+
+    # Act
+    state_out = istio_core_context.run(
+        istio_core_context.on.relation_joined(relation), state=state
+    )
+
+    # Assert
+    assert state_out.get_relation(relation.id).local_app_data == expected
+
+
+@pytest.mark.parametrize("model_name", ["istio", "istio-system"])
+def test_provider_sends_data_on_leader_elected(istio_core_context, model_name):
+    """Tests that a charm using IstioMetadataProvider sends data on a leader elected event."""
+    # Arrange
+    relation = Relation(RELATION_NAME, INTERFACE_NAME)
+    relations = [relation]
+
+    state = State(
+        relations=relations,
+        leader=True,
+        model=Model(model_name),
+    )
+
+    expected = {"root_namespace": model_name}
+
+    event = getattr(istio_core_context.on, "leader_elected")()
+
+    # Act
+    state_out = istio_core_context.run(event, state=state)
+
+    # Assert
+    assert state_out.get_relation(relation.id).local_app_data == expected

--- a/tests/scenario/test_istio_metadata_lib.py
+++ b/tests/scenario/test_istio_metadata_lib.py
@@ -1,0 +1,131 @@
+"""Tests for the istio-metadata lib requirer and provider classes, excluding their usage in IstioCharm."""
+
+from typing import Union
+
+import pytest
+from charms.istio_k8s.v0.istio_metadata import (
+    IstioMetadataAppData,
+    IstioMetadataProvider,
+    IstioMetadataRequirer,
+)
+from ops import CharmBase
+from ops.testing import Context, Relation, State
+
+RELATION_NAME = "app-data-relation"
+INTERFACE_NAME = "app-data-interface"
+
+# Note: if this is changed, the IstioMetadataAppData concrete classes below need to change their constructors to match
+SAMPLE_APP_DATA = IstioMetadataAppData(root_namespace="root-namespace")
+SAMPLE_APP_DATA_2 = IstioMetadataAppData(root_namespace="root-namespace-2")
+
+
+class IstioMetadataProviderCharm(CharmBase):
+    META = {
+        "name": "provider",
+        "provides": {RELATION_NAME: {"interface": INTERFACE_NAME}},
+    }
+
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.relation_provider = IstioMetadataProvider(
+            relation_mapping=self.model.relations,
+            app=self.app,
+            relation_name=RELATION_NAME,  # pyright: ignore
+        )
+
+
+@pytest.fixture()
+def istio_metadata_provider_context():
+    return Context(charm_type=IstioMetadataProviderCharm, meta=IstioMetadataProviderCharm.META)
+
+
+class IstioMetadataRequirerCharm(CharmBase):
+    META = {
+        "name": "requirer",
+        "requires": {RELATION_NAME: {"interface": INTERFACE_NAME}},
+    }
+
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.relation_requirer = IstioMetadataRequirer(
+            self.model.relations, relation_name=RELATION_NAME
+        )
+
+
+@pytest.fixture()
+def istio_metadata_requirer_context():
+    return Context(charm_type=IstioMetadataRequirerCharm, meta=IstioMetadataRequirerCharm.META)
+
+
+@pytest.mark.parametrize("data", [SAMPLE_APP_DATA, SAMPLE_APP_DATA_2])
+def test_istio_metadata_provider_sends_data_correctly(data, istio_metadata_provider_context):
+    """Tests that a charm using IstioMetadataProvider sends the correct data during publish."""
+    # Arrange
+    istio_metadata_relation = Relation(RELATION_NAME, INTERFACE_NAME, local_app_data={})
+    relations = [istio_metadata_relation]
+    state = State(relations=relations, leader=True)
+
+    # Act
+    with istio_metadata_provider_context(
+        # construct a charm using an event that won't trigger anything here
+        istio_metadata_provider_context.on.update_status(),
+        state=state,
+    ) as manager:
+        manager.charm.relation_provider.publish(**data.model_dump())
+
+    # Assert
+    # Convert local_app_data to TempoApiAppData for comparison
+    actual = IstioMetadataAppData.model_validate(dict(istio_metadata_relation.local_app_data))
+    assert actual == data
+
+
+@pytest.mark.parametrize(
+    "relations, expected_data",
+    [
+        # no relations
+        ([], None),
+        # one empty relation
+        (
+            [Relation(RELATION_NAME, INTERFACE_NAME, remote_app_data={})],
+            None,
+        ),
+        # one populated relation
+        (
+            [
+                Relation(
+                    RELATION_NAME,
+                    INTERFACE_NAME,
+                    remote_app_data=SAMPLE_APP_DATA.model_dump(mode="json"),
+                )
+            ],
+            SAMPLE_APP_DATA,  # pyright: ignore
+        ),
+    ],
+)
+def test_istio_metadata_requirer_get_data(
+    relations, expected_data, istio_metadata_requirer_context
+):
+    """Tests that IstioMetadataRequirer.get_data() returns correctly."""
+    state = State(
+        relations=relations,
+        leader=False,
+    )
+
+    with istio_metadata_requirer_context(
+        istio_metadata_requirer_context.on.update_status(), state=state
+    ) as manager:
+        charm = manager.charm
+
+        data = charm.relation_requirer.get_data()
+        assert are_app_data_equal(data, expected_data)
+
+
+def are_app_data_equal(
+    data1: Union[IstioMetadataAppData, None], data2: Union[IstioMetadataAppData, None]
+):
+    """Compare two IstioMetadataRequirer objects, tolerating when one or both is None."""
+    if data1 is None and data2 is None:
+        return True
+    if data1 is None or data2 is None:
+        return False
+    return data1.model_dump() == data2.model_dump()

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ description = Run scenario tests
 deps =
     -r{toxinidir}/requirements.txt
     pytest
-    ops-scenario
+    ops[testing]
 commands =
     pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario
 


### PR DESCRIPTION
## Issue
Some other applications, such as Kiali, need additional metadata about the istio installation.

## Solution
Adds an istio-metadata relation using the istio-metadata interface.  This interface is used for transferring metadata about the istio installation.  Currently, it only sends Istio's root namespace

## Context
-

## Testing Instructions
Unit tests should cover everything

## Upgrade Notes
-