### PR TITLE
feat: bump istio to 1.26.1

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -92,7 +92,7 @@ parts:
       git describe --always > $CRAFT_PART_INSTALL/version
   istioctl:
     plugin: dump
-    source: https://github.com/istio/istio/releases/download/1.24.0/istioctl-1.24.0-linux-amd64.tar.gz
+    source: https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-linux-amd64.tar.gz
     source-type: tar
 
 


### PR DESCRIPTION
bumping to at least istio 1.25 because 1.25 is the version where istio lets us [apply allow nothing policies to waypoints by default](https://github.com/istio/istio/pull/54780), which is needed to lock down the mesh.