### PR TITLE
fix: enable proper scaling of istio core charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -81,6 +81,10 @@ requires:
       Provides an interface for exchanging Istio ingress configuration,
       including external authorizer configuration details.
 
+peers:
+  peers:
+    interface: istio_k8s_peers
+
 parts:
   charm:
     source: .

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from typing import Optional
+
+from lightkube.core.client import Client
+from lightkube.resources.autoscaling_v2 import HorizontalPodAutoscaler
+
+logger = logging.getLogger(__name__)
+
+
+async def get_hpa(namespace: str, hpa_name: str) -> Optional[HorizontalPodAutoscaler]:
+    """Retrieve the HPA resource so we can inspect .spec and .status directly.
+
+    Args:
+        namespace: Namespace of the HPA resource.
+        hpa_name: Name of the HPA resource.
+
+    Returns:
+        The HorizontalPodAutoscaler object or None if not found / on error.
+    """
+    try:
+        c = Client()
+        return c.get(HorizontalPodAutoscaler, namespace=namespace, name=hpa_name)
+    except Exception as e:
+        logger.error("Error retrieving HPA %s: %s", hpa_name, e, exc_info=True)
+        return None

--- a/tests/integration/test_charm_scaling.py
+++ b/tests/integration/test_charm_scaling.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import get_hpa
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+resources = {
+    "metrics-proxy-image": METADATA["resources"]["metrics-proxy-image"]["upstream-source"],
+}
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, istio_core_charm):
+    """Build the charm-under-test and deploy it."""
+    # Deploy the charm and wait for active/idle status
+    await asyncio.gather(
+        ops_test.model.deploy(
+            istio_core_charm, resources=resources, application_name=APP_NAME, trust=True
+        ),
+        ops_test.model.wait_for_idle(
+            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
+        ),
+    )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.parametrize(
+    "n_units",
+    (
+        # Scale up from 1 to 3
+        3,
+        # Scale down to 2
+        2,
+    ),
+)
+async def test_istiod_scaling(ops_test: OpsTest, n_units):
+    """Tests that, when the application is scaled, the HPA managing istiod Deployment is scaled too.
+
+    Note: This test is stateful and will leave the deployment at a scale of 2.
+    """
+    assert ops_test.model
+    await ops_test.model.applications[APP_NAME].scale(n_units)
+    await ops_test.model.wait_for_idle(
+        [APP_NAME],
+        status="active",
+        timeout=2000,
+        raise_on_error=False,
+    )
+
+
+    istiod_hpa = await get_hpa(ops_test.model.name, "istiod")
+    assert istiod_hpa is not None
+    assert istiod_hpa.spec.minReplicas == n_units  # pyright: ignore
+    assert istiod_hpa.spec.maxReplicas == n_units  # pyright: ignore
+
+    assert await wait_for_hpa_current_replicas(
+        ops_test.model.name, "istiod", n_units
+    ), f"Expected currentReplicas to be {n_units}, got {istiod_hpa.status.currentReplicas}"  # pyright: ignore
+
+
+@pytest.mark.abort_on_fail
+async def wait_for_hpa_current_replicas(
+    namespace, hpa_name, expected_replicas, retries=10, delay=10
+):
+    for _ in range(retries):
+        # freshly grab the hpa, but no need to assert its existence as that should be
+        # checked by the caller of this method
+        istiod_hpa = await get_hpa(namespace, hpa_name)
+        if istiod_hpa.status.currentReplicas == expected_replicas:  # pyright: ignore
+            return True
+        await asyncio.sleep(delay)
+    return False

--- a/tests/unit/test_istio_metadata_lib.py
+++ b/tests/unit/test_istio_metadata_lib.py
@@ -28,6 +28,7 @@ class IstioMetadataProviderCharm(CharmBase):
     def __init__(self, framework):
         super().__init__(framework)
         self.relation_provider = IstioMetadataProvider(
+            charm=self,
             relation_mapping=self.model.relations,
             app=self.app,
             relation_name=RELATION_NAME,  # pyright: ignore


### PR DESCRIPTION
## Issue
As mentioned in the issue #22, the istio-k8s charmed did not scale properly.. So far even though the charm scaled, the istio components (istiod) did not scale with the charm. 


## Solution
As commented [here](https://github.com/canonical/istio-k8s-operator/issues/22#issuecomment-2822786271), the major components of the istio-k8s charm are 
- `ztunnel` which is a `DaemonSet` already and doesnt need to be scaled.
- Same applies for `istio-cni-node` which is also a `DaemonSet`
- `istiod` which needs to scale along with the charm

The solution follows the same patters as the one used by [istio-ingress-k8s](https://github.com/canonical/istio-ingress-k8s-operator/pull/61) and `istio-beacon-k8s`. `The HorizontalPodAutoscaler` (HPA) attached to the `ztunnel Deployment` is configured so that the `minReplicas` and `maxReplicas` of the HPA are same as that of the number of units of the charm. 

## Context
In case of `istio-k8s` since the manifest for the `istiod` HPA is autogenetated by `istioctl`, the solution in this PR provides a way to conveniently and in a fool-proof way override the specs of the autogenerated manifest.

Also reconciliation is put behind a leader-guard similar to other istio charms.

## Testing Instructions
- Pull the PR
- pack the charm
- deploy the charm
- scale the charm and verify the number of pods of istiod matches the number of charm units