### PR TITLE
feat: adds headers to ingress config interface data model

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -415,16 +415,10 @@ class IstioCoreCharm(ops.CharmBase):
                         "envoyExtAuthzHttp": {
                             "service": ext_authz_info.ext_authz_service_name,  # type: ignore
                             "port": ext_authz_info.ext_authz_port,  # type: ignore
-                            "includeRequestHeadersInCheck": ["authorization", "cookie"],
-                            "headersToUpstreamOnAllow": [
-                                "authorization",
-                                "path",
-                                "x-auth-request-user",
-                                "x-auth-request-email",
-                                "x-auth-request-access-token",
-                            ],
-                            "headersToDownstreamOnAllow": ["set-cookie"],
-                            "headersToDownstreamOnDeny": ["content-type", "set-cookie"],
+                            "includeRequestHeadersInCheck": ext_authz_info.include_headers_in_check,  # type: ignore
+                            "headersToUpstreamOnAllow": ext_authz_info.headers_to_upstream_on_allow,  # type: ignore
+                            "headersToDownstreamOnAllow": ext_authz_info.headers_to_downstream_on_allow,  # type: ignore
+                            "headersToDownstreamOnDeny": ext_authz_info.headers_to_downstream_on_deny,  # type: ignore
                         },
                     }
                 )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -58,6 +58,16 @@ def ingress_config():
         remote_app_data={
             "ext_authz_service_name": "oauth-service",
             "ext_authz_port": "8080",
+            "include_headers_in_check": json.dumps(["authorization", "cookie"]),
+            "headers_to_upstream_on_allow": json.dumps([
+                "authorization",
+                "path",
+                "x-auth-request-user",
+                "x-auth-request-email",
+                "x-auth-request-access-token",
+            ]),
+            "headers_to_downstream_on_allow": json.dumps(["set-cookie"]),
+            "headers_to_downstream_on_deny": json.dumps(["content-type", "set-cookie"]),
         },
         local_app_data={},
     )


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/istio-ingress-k8s-operator/issues/121


## Context and Solution
for external authorization, istio lets various headers to be defined. currently, these headers in the charm are hardcoded to be the oauth2_proxy standards. but the OAuth provider can be varying and the header values depends on the provider. The `forward_auth` library allows the OAuth provider to specify the headers to be passed to the upstream service on successful authentication. This PR extends the `istio_ingress_config` to pass these headers to the `istio-k8s` charm.


## Testing instructions
The manual testing instructions [here](https://github.com/canonical/istio-ingress-k8s-operator/tree/main/tests/manual/auth) can be used to test the auth and verify the working. (But the hydra based oauth provider uses oauth2 proxy, so we will still see the default headers)

## Breaking change?
This is not a breaking change as the additional header fields in the relation data model are optional with oauth2_proxy defaults. 
