### PR TITLE
chore: use image from the oci factory

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -118,7 +118,7 @@ parts:
       git describe --always > $CRAFT_PART_INSTALL/version
   istioctl:
     plugin: dump
-    source: https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-linux-amd64.tar.gz
+    source: https://github.com/istio/istio/releases/download/1.29.0/istioctl-1.29.0-linux-amd64.tar.gz
     source-type: tar
 
 charm-libs:
@@ -129,6 +129,4 @@ resources:
   metrics-proxy-image:
     type: oci-image
     description: Metrics Proxy OCI image
-    # TODO: change below to point at the correct image once metrics-proxy rock is onboarded
-    # see: https://github.com/canonical/oci-factory/issues/268
-    upstream-source: docker.io/ibraaoad/metrics-proxy:v0.1.0
+    upstream-source: docker.io/ubuntu/metrics-proxy:0.1.1-24.04_stable

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,6 +87,14 @@ ISTIO_CRDS_RESOURCE_TYPES = {CustomResourceDefinition}
 GATEWAY_API_CRDS_MANIFEST = [SOURCE_PATH / "manifests" / "gateway-apis-crds.yaml"]
 GATEWAY_API_CRDS_LABEL = "gateway-apis-crds"
 GATEWAY_API_CRDS_RESOURCE_TYPES = {CustomResourceDefinition}
+
+# Rock image settings
+ROCK_REGISTRY = "docker.io/ubuntu"
+ISTIO_VERSION = "1.29.0"
+ISTIO_ROCK_TAG = f"{ISTIO_VERSION}-24.04_stable"
+PILOT_IMAGE = "istio-pilot"
+CNI_IMAGE = "istio-install-cni"
+ZTUNNEL_IMAGE = "istio-ztunnel"
 RESOURCE_TYPES = {
     "AuthorizationPolicy": create_namespaced_resource(
         "security.istio.io",
@@ -188,8 +196,9 @@ class IstioCoreCharm(ops.CharmBase):
                     "metrics-proxy": {
                         "override": "replace",
                         "summary": "Metrics Broadcast Proxy",
-                        "command": f"metrics-proxy --labels {self.format_labels(self.telemetry_labels)}",
+                        "command": "metrics-proxy",
                         "startup": "enabled",
+                        "environment": {"POD_LABEL_SELECTOR": self.format_labels(self.telemetry_labels)},
                     }
                 },
             }
@@ -581,6 +590,17 @@ class IstioCoreCharm(ops.CharmBase):
 
         if self.parsed_config["auto-allow-waypoint-policy"]:
             setting_overrides["values.pilot.env.PILOT_AUTO_ALLOW_WAYPOINT_POLICY"] = "true"
+
+        # Use Canonical rock images for Istio components (envoy/proxyv2 stays upstream)
+        setting_overrides["values.pilot.hub"] = ROCK_REGISTRY
+        setting_overrides["values.pilot.image"] = PILOT_IMAGE
+        setting_overrides["values.pilot.tag"] = ISTIO_ROCK_TAG
+        setting_overrides["values.cni.hub"] = ROCK_REGISTRY
+        setting_overrides["values.cni.image"] = CNI_IMAGE
+        setting_overrides["values.cni.tag"] = ISTIO_ROCK_TAG
+        setting_overrides["values.ztunnel.hub"] = ROCK_REGISTRY
+        setting_overrides["values.ztunnel.image"] = ZTUNNEL_IMAGE
+        setting_overrides["values.ztunnel.tag"] = ISTIO_ROCK_TAG
 
         overlay_files = []
         ca_bundle = self._get_ca_certificates()

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,6 +38,7 @@ from lightkube.models.autoscaling_v2 import (
     CrossVersionObjectReference,
     HorizontalPodAutoscalerSpec,
 )
+from lightkube.models.core_v1 import EmptyDirVolumeSource, EnvVar, Volume, VolumeMount
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.admissionregistration_v1 import (
     MutatingWebhookConfiguration,
@@ -90,7 +91,7 @@ GATEWAY_API_CRDS_RESOURCE_TYPES = {CustomResourceDefinition}
 
 # Rock image settings
 ROCK_REGISTRY = "docker.io/ubuntu"
-ISTIO_VERSION = "1.29.0"
+ISTIO_VERSION = "1.29"
 ISTIO_ROCK_TAG = f"{ISTIO_VERSION}-24.04_stable"
 PILOT_IMAGE = "istio-pilot"
 CNI_IMAGE = "istio-install-cni"
@@ -351,6 +352,7 @@ class IstioCoreCharm(ops.CharmBase):
             )
 
             resources = codecs.load_all_yaml(manifests, create_resources_for_crds=True)
+            resources = self._patch_pebble_runtime(resources)
             resources = self._add_metrics_labels(resources)
 
         krm = self._get_resource_manager(CONTROL_PLANE_LABEL)
@@ -601,6 +603,8 @@ class IstioCoreCharm(ops.CharmBase):
         setting_overrides["values.ztunnel.hub"] = ROCK_REGISTRY
         setting_overrides["values.ztunnel.image"] = ZTUNNEL_IMAGE
         setting_overrides["values.ztunnel.tag"] = ISTIO_ROCK_TAG
+        # Disable the default distroless variant suffix that istioctl appends to image tags
+        setting_overrides["values.global.variant"] = ""
 
         overlay_files = []
         ca_bundle = self._get_ca_certificates()
@@ -614,6 +618,54 @@ class IstioCoreCharm(ops.CharmBase):
             setting_overrides=setting_overrides,
             overlay_files=overlay_files,
         )
+
+    @staticmethod
+    def _patch_pebble_runtime(resources: List[AnyResource]) -> List[AnyResource]:
+        """Patch resources for compatibility with Pebble-based rocks.
+
+        Rocks use Pebble as their OCI entrypoint, which requires three adjustments:
+        1. A writable emptyDir volume at /run/pebble for Pebble state files (socket, identity),
+           since Istio enforces readOnlyRootFilesystem: true on istiod and ztunnel.
+        2. PEBBLE and PEBBLE_COPY_ONCE env vars to redirect Pebble's runtime directory to the
+           writable mount and copy baked-in layer config from /var/lib/pebble/default on first
+           start.
+        3. Stripping container args from ztunnel — istioctl injects ["proxy", "ztunnel"] which
+           Pebble misinterprets as subcommands. The istiod (pilot) rock uses entrypoint-service
+           with argument forwarding so its args are kept.
+        """
+        # (resource kind, resource name) -> (container name, strip_args)
+        pebble_targets = {
+            ("Deployment", "istiod"): ("discovery", False),
+            ("DaemonSet", "ztunnel"): ("istio-proxy", True),
+        }
+        for resource in resources:
+            key = (resource.kind, resource.metadata.name)  # pyright: ignore
+            target = pebble_targets.get(key)  # pyright: ignore
+            if target is None:
+                continue
+            container_name, strip_args = target
+
+            spec = resource.spec.template.spec  # pyright: ignore
+            if spec.volumes is None:
+                spec.volumes = []
+            spec.volumes.append(Volume(name="pebble-state", emptyDir=EmptyDirVolumeSource()))
+            for container in spec.containers:
+                if container.name == container_name:
+                    if container.volumeMounts is None:
+                        container.volumeMounts = []
+                    container.volumeMounts.append(
+                        VolumeMount(name="pebble-state", mountPath="/run/pebble")
+                    )
+                    if container.env is None:
+                        container.env = []
+                    container.env.extend([
+                        EnvVar(name="PEBBLE", value="/run/pebble"),
+                        EnvVar(name="PEBBLE_COPY_ONCE", value="/var/lib/pebble/default"),
+                    ])
+                    if strip_args:
+                        container.args = None
+                    break
+        return resources
 
     def _add_metrics_labels(self, resources: List[AnyResource]) -> List[AnyResource]:
         """Append extra labels to the ztunnel, istio-cni-node, and istiod pods based on METRICS_LABELS."""

--- a/src/istioctl.py
+++ b/src/istioctl.py
@@ -132,7 +132,7 @@ class Istioctl:
         command = [self._istioctl_path, *args]
         logger.info(f"Running command: {' '.join(command)}")
         try:
-            output = subprocess.check_output(command)
+            output = subprocess.check_output(command, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as cpe:
             istioctl_error = IstioctlError(
                 f"Failed to run command {' '.join(command)} with error code {cpe.returncode}",
@@ -169,6 +169,13 @@ class Istioctl:
         """Return istio client and control plane versions."""
         args = ["version", f"-i={self._namespace}", "-o=yaml"]
         version_string = self._run(*args)
+
+        # istioctl may emit structured log lines (with tab separators) to stdout
+        # before the YAML output when the control plane is not fully ready.
+        # Strip any non-YAML preamble to avoid yaml.safe_load failures.
+        yaml_start = version_string.find("clientVersion:")
+        if yaml_start > 0:
+            version_string = version_string[yaml_start:]
 
         version_dict = yaml.safe_load(version_string)
         return {

--- a/tests/unit/test_istioctl.py
+++ b/tests/unit/test_istioctl.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -96,7 +97,7 @@ def test_istioctl_install_no_setting_overrides(mocked_check_output):
     ]
     expected_call_args.extend(EXPECTED_ISTIOCTL_FLAGS)
 
-    mocked_check_output.assert_called_once_with(expected_call_args)
+    mocked_check_output.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
 
 def test_istioctl_install_setting_overrides(mocked_check_output):
@@ -121,7 +122,7 @@ def test_istioctl_install_setting_overrides(mocked_check_output):
     for k, v in setting_overrides.items():
         expected_call_args.extend(["--set", f"{k}={v}"])
 
-    mocked_check_output.assert_called_once_with(expected_call_args)
+    mocked_check_output.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
 
 def test_istioctl_install_error(mocked_check_output_failing):
@@ -146,7 +147,7 @@ def test_istioctl_manifest(mocked_check_output):
     ]
     expected_call_args.extend(EXPECTED_ISTIOCTL_FLAGS)
 
-    mocked_check_output.assert_called_once_with(expected_call_args)
+    mocked_check_output.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
     # Assert that we received the expected manifests from istioctl
     expected_manifest = "stdout"
@@ -177,7 +178,7 @@ def test_istioctl_manifest_with_setting_overrides_and_components(mocked_check_ou
     for c in components:
         expected_call_args.extend(["--set", f"components.{c}.enabled=true"])
 
-    mocked_check_output.assert_called_once_with(expected_call_args)
+    mocked_check_output.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
 
 def test_istioctl_manifest_error(mocked_check_output_failing):
@@ -215,7 +216,7 @@ def test_istioctl_manifest_with_lightkube_overrides(mocked_check_output_manifest
         "generate",
     ]
     expected_call_args.extend(EXPECTED_ISTIOCTL_FLAGS)
-    mocked_check_output_manifest.assert_called_once_with(expected_call_args)
+    mocked_check_output_manifest.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
     # Verify the override was applied
     docs = list(yaml.safe_load_all(manifest))
@@ -238,7 +239,7 @@ def test_istioctl_remove(mocked_check_output):
 
     ictl.uninstall()
 
-    mocked_check_output.assert_called_once_with([ISTIOCTL_BINARY, "uninstall", "--purge", "-y"])
+    mocked_check_output.assert_called_once_with([ISTIOCTL_BINARY, "uninstall", "--purge", "-y"], stderr=subprocess.PIPE)
 
 
 def test_istioctl_remove_error(mocked_check_output_failing):
@@ -253,7 +254,7 @@ def test_istioctl_precheck(mocked_check_output):
 
     ictl.precheck()
 
-    mocked_check_output.assert_called_once_with([ISTIOCTL_BINARY, "x", "precheck"])
+    mocked_check_output.assert_called_once_with([ISTIOCTL_BINARY, "x", "precheck"], stderr=subprocess.PIPE)
 
 
 def test_istioctl_precheck_error(mocked_check_output_failing):
@@ -275,7 +276,7 @@ def test_istioctl_upgrade(mocked_check_output):
     ]
     expected_call_args.extend(EXPECTED_ISTIOCTL_FLAGS)
 
-    mocked_check_output.assert_called_once_with(expected_call_args)
+    mocked_check_output.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
 
 def test_istioctl_upgrade_error(mocked_check_output_failing):
@@ -310,7 +311,8 @@ def test_istioctl_version(mocked_check_output):
             "version",
             f"-i={NAMESPACE}",
             "-o=yaml",
-        ]
+        ],
+        stderr=subprocess.PIPE,
     )
 
     assert version_data["client"] == expected_client_version
@@ -415,7 +417,7 @@ def test_istioctl_overlay_files(mocked_check_output):
     expected_call_args.extend(EXPECTED_ISTIOCTL_FLAGS)
     expected_call_args.extend(["-f", "/tmp/overlay1.yaml", "-f", "/tmp/overlay2.yaml"])
 
-    mocked_check_output.assert_called_once_with(expected_call_args)
+    mocked_check_output.assert_called_once_with(expected_call_args, stderr=subprocess.PIPE)
 
 
 def test_istioctl_no_overlay_files(mocked_check_output):


### PR DESCRIPTION
## Issue
Updates the istio related images to be pulled from the oci factory (except for the istio envoy). 
Fixes #57 

