### PR TITLE
fix: include icon.svg in the final charm file

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -110,6 +110,11 @@ parts:
     plugin: dump
     source: https://github.com/istio/istio/releases/download/1.26.1/istioctl-1.26.1-linux-amd64.tar.gz
     source-type: tar
+  icon:
+    plugin: dump
+    source: .
+    stage:
+      - icon.svg
 
 resources:
   metrics-proxy-image:


### PR DESCRIPTION
The icon file must be explicitly referenced to be included in the final .charm file.