### PR TITLE
fix: include icon.svg in the final charm file

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -120,6 +120,11 @@ parts:
     plugin: dump
     source: https://github.com/istio/istio/releases/download/1.29.0/istioctl-1.29.0-linux-amd64.tar.gz
     source-type: tar
+  icon:
+    plugin: dump
+    source: .
+    stage:
+      - icon.svg
 
 charm-libs:
   - lib: "certificate_transfer_interface.certificate_transfer"


### PR DESCRIPTION
The icon file must be explicitly referenced to be included in the final .charm file.